### PR TITLE
Add configuration for Focus (Android).

### DIFF
--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -41,6 +41,12 @@ taskgraph:
             default-repository: https://github.com/mozilla-lockwise/lockwise-android
             default-ref: master
             type: git
+        focusandroid:
+            name: "Focus Android"
+            project-regex: focus-android
+            default-repository: https://github.com/mozilla-mobile/focus-android
+            default-ref: main
+            type: git
     cached-task-prefix: l10n.android-l10n-tooling
 
 workers:

--- a/taskcluster/ci/update-l10n/kind.yml
+++ b/taskcluster/ci/update-l10n/kind.yml
@@ -33,3 +33,6 @@ jobs:
         repo-prefix: ac
     mozilla-mobile/fenix:
         repo-prefix: fenix
+    mozilla-mobile/focus-android:
+        repo-prefix: focusandroid
+

--- a/taskcluster/ci/update-project/kind.yml
+++ b/taskcluster/ci/update-project/kind.yml
@@ -36,3 +36,7 @@ jobs:
     mozilla-mobile/fenix:
         repo-prefix: fenix
         pr-target: master
+    mozilla-mobile/focus-android:
+        repo-prefix: focusandroid
+        pr-target: main
+


### PR DESCRIPTION
Adding Firefox Focus for Android to the configuration. The initial import into the `android-l10n` repository happens here: https://github.com/mozilla-l10n/android-l10n/pull/328