### PR TITLE
Fixes #33 - Change android-components branch from master to main

### DIFF
--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -33,7 +33,7 @@ taskgraph:
             name: "Android Components"
             project-regex: android-components
             default-repository: https://github.com/mozilla-mobile/android-components
-            default-ref: master
+            default-ref: main
             type: git
         lockwise:
             name: "Lockwise"

--- a/taskcluster/ci/update-project/kind.yml
+++ b/taskcluster/ci/update-project/kind.yml
@@ -32,7 +32,7 @@ jobs:
         pr-target: master
     mozilla-mobile/android-components:
         repo-prefix: ac
-        pr-target: master
+        pr-target: main
     mozilla-mobile/fenix:
         repo-prefix: fenix
         pr-target: master


### PR DESCRIPTION
This patch changes the branch used for `android-components` from `master` to `main`. I did not find any other branch name references in these scripts.

> It looks like the checks are failing because the `main` branch does not exist yet.