### PR TITLE
Fixes #36 - Change Fenix branch from master to main

### DIFF
--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -27,7 +27,7 @@ taskgraph:
             name: "Fenix"
             project-regex: fenix
             default-repository: https://github.com/mozilla-mobile/fenix
-            default-ref: master
+            default-ref: main
             type: git
         ac:
             name: "Android Components"

--- a/taskcluster/ci/update-l10n/kind.yml
+++ b/taskcluster/ci/update-l10n/kind.yml
@@ -34,6 +34,7 @@ jobs:
         pr-target: main
     mozilla-mobile/fenix:
         repo-prefix: fenix
+        pr-target: main
     mozilla-mobile/focus-android:
         repo-prefix: focusandroid
 

--- a/taskcluster/ci/update-project/kind.yml
+++ b/taskcluster/ci/update-project/kind.yml
@@ -35,7 +35,7 @@ jobs:
         pr-target: main
     mozilla-mobile/fenix:
         repo-prefix: fenix
-        pr-target: master
+        pr-target: main
     mozilla-mobile/focus-android:
         repo-prefix: focusandroid
         pr-target: main


### PR DESCRIPTION
This patch changes the branch used for Fenix from `master` to `main`. This patch should land when we do the rename in Fenix.