### PR TITLE
Remove Lockwise

### DIFF
--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -35,12 +35,6 @@ taskgraph:
             default-repository: https://github.com/mozilla-mobile/android-components
             default-ref: main
             type: git
-        lockwise:
-            name: "Lockwise"
-            project-regex: lockwise-android
-            default-repository: https://github.com/mozilla-lockwise/lockwise-android
-            default-ref: master
-            type: git
         focusandroid:
             name: "Focus Android"
             project-regex: focus-android

--- a/taskcluster/ci/update-l10n/kind.yml
+++ b/taskcluster/ci/update-l10n/kind.yml
@@ -27,8 +27,6 @@ job-defaults:
         command: ['create-l10n-branch', '--repo', '{project}', '--branch', '{repo_name}-quarantine', 'android-l10n']
 
 jobs:
-    mozilla-lockwise/lockwise-android:
-        repo-prefix: lockwise
     mozilla-mobile/android-components:
         repo-prefix: ac
     mozilla-mobile/fenix:

--- a/taskcluster/ci/update-project/kind.yml
+++ b/taskcluster/ci/update-project/kind.yml
@@ -27,9 +27,6 @@ job-defaults:
         command: ['import-android-l10n', 'android-l10n/{project}/l10n.toml', '{project}']
 
 jobs:
-    mozilla-lockwise/lockwise-android:
-        repo-prefix: lockwise
-        pr-target: master
     mozilla-mobile/android-components:
         repo-prefix: ac
         pr-target: main


### PR DESCRIPTION
Lockwise is long gone, it should be removed (cc @bcolsson)

A couple of additional questions:
* I'm creating the PR here based on #31, but normally the localization PM would send an email to request the removal. We have [documentation](https://mozilla-l10n.github.io/documentation/products/android-l10n/removing_projects.html#contact-release-engineering) about it, but naming individuals never age well (doc is already outdated). What's the best way to reach out to the relevant RelEng folks via email? Is there an alias that should be used?
* Are there additional dependencies outside of this repository to stop the automation?