### PR TITLE
Bug 1786793 - part 2: Link firefox-android to the `main` branch

### DIFF
--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -45,7 +45,7 @@ taskgraph:
             name: "Firefox Android"
             project-regex: firefox-android
             default-repository: https://github.com/mozilla-mobile/firefox-android
-            default-ref: ac-prep
+            default-ref: main
             type: git
     cached-task-prefix: l10n.android-l10n-tooling
 

--- a/taskcluster/ci/update-project/kind.yml
+++ b/taskcluster/ci/update-project/kind.yml
@@ -40,7 +40,7 @@ jobs:
         pr-target: main
     mozilla-mobile/firefox-android:
         repo-prefix: firefoxandroid
-        pr-target: ac-prep  # TODO: Change to main once we migrated android-components over
+        pr-target: main
         # Note: Path to `l10n.toml` includes a subfolder because the monorepo will contain
         # one subfolder per android product
         #


### PR DESCRIPTION
Depends on https://github.com/mozilla-l10n/android-l10n-tooling/pull/48 and https://github.com/mozilla-l10n/android-l10n/pull/520