### PR TITLE
Bug 1799698 - Append the project name to the branch name to avoid branch conflicts

### DIFF
--- a/src/mozxchannel/android/importer.py
+++ b/src/mozxchannel/android/importer.py
@@ -17,13 +17,14 @@ def main():
     porter = Importer(args.l10n_toml, args.dest)
     porter.import_strings()
 
-    # Not sure if creating and resetting the same "import-l10n" branch would cause issues
-    # when importing strings from Focus and AC in the monorepo.
-    # eg, Would this overwrite changes from a prior job if there are changes coming from
-    # both Focus and AC?
-    # Easy fix would be to append the args.dest to the branch name.
+    if "firefox-android" in args.dest:
+        top_folder_name = args.dest.split("/")[-1]
+        target_branch_name = f"import-l10n-{top_folder_name}"
+    else:
+        target_branch_name = "import-l10n"
+
     subprocess.run(
-        ["git", "-C", args.dest, "checkout", "-B", "import-l10n"], check=True
+        ["git", "-C", args.dest, "checkout", "-B", target_branch_name], check=True
     )
     subprocess.run(
         ["git", "-C", args.dest, "add", "-v", "-A"], check=True


### PR DESCRIPTION
We are appending the project name to the branch name to avoid branch conflicts that was seen in https://github.com/mozilla-mobile/firefox-android/pull/257
https://github.com/mozilla-mobile/firefox-android/pull/251

This could happen because we are reusing the same branch names for importing strings. If we have 2 jobs (Focus and AC) that are running to import the strings to the monorepo, each job is creating the same branch for the imports. So, if there are strings to sync from both job, the job can effectively be overriding the previous jobs’ branch over and over again each time