### PR TITLE
Bug 1799698 - part 4:  Append the org and project name to the quarantine branch name to avoid branch conflicts

### DIFF
--- a/taskcluster/l10n_taskgraph/update.py
+++ b/taskcluster/l10n_taskgraph/update.py
@@ -40,7 +40,11 @@ def update_l10n(config, jobs):
 def add_l10n_toml_path(config, jobs):
     for job in jobs:
         project = job["name"]
+
         repo_name = project.split("/")[1]
+        if "firefox-android" in project:
+            repo_name = "{}-{}".format(repo_name, project.split("/")[2])
+
         l10n_toml_path = job.pop("l10n-toml-path", "")
         l10n_toml_path = l10n_toml_path.format(project=project)
 


### PR DESCRIPTION
In https://github.com/mozilla-l10n/android-l10n/pull/557, we are running into branch conflicts because the `create-l10n-branch` tasks are using the same `firefox-android-quarantine` branch for both the AC and Focus tasks. This PR adds the project name to the naming.