### PR TITLE
No issue - Remove code generating the toml paths

### DIFF
--- a/src/mozxchannel/git/repository.py
+++ b/src/mozxchannel/git/repository.py
@@ -105,19 +105,48 @@ class TargetRepository(Repository):
         self.checkout(branch)
 
     def converted_revs(self):
+        print("converted_revs: Go into android-l10n _meta directory and load all the json data.")
+
         branch = self.git.lookup_branch(self.target_branch).target
         tree = self[branch].tree
         if '_meta' not in tree:
             return {}
+
+        # print("converted_revs - tree['_meta']")
+        # print(tree['_meta'])
+        # print(tree['_meta'].id)
+
         tree = self[tree['_meta'].id]
+
+        # print("converted_revs - tree")
+        # print(tree)
+
         revs = {}
         for treeitem in tree:
             data = json.loads(self[treeitem.id].data)
+
+            # print(data)
+
             revs[data['name']] = data['revs']
+
+        print("converted_revs - revs:")
+        print(revs)
+
         return revs
 
     def known_revs(self):
+        print("known_revs")
+        print("--------------------------------------")
+
         revs = set()
         for branch_revs in self.converted_revs().values():
+            print("known_revs - branch_revs")
+            print(branch_revs)
+            print("known_revs - branch_revs.values()")
+            print(branch_revs.values())
+
             revs.update(branch_revs.values())
+
+        print(revs)
+
         return revs

--- a/src/mozxchannel/walker.py
+++ b/src/mozxchannel/walker.py
@@ -8,6 +8,9 @@ class GraphWalker(object):
         self.graph = graph
 
     def walkGraph(self):
+        print("walkGraph")
+        print("--------------------------------------")
+
         self.visited = set()
         self.waiting = set()
         self.queue = self.graph.roots[:]


### PR DESCRIPTION
There has been conversations that the [android-l10n/l10n.toml](https://github.com/mozilla-l10n/android-l10n/blob/master/l10n.toml) is unneeded and we should remove it. The first step here is to remove the code that is currently updating the include paths in the file. An example can be seen in this PR https://github.com/mozilla-l10n/android-l10n/pull/572/files