### PR TITLE
Bug 1807027 - Part 3: Use the correct repo name when getting the known_revs

### DIFF
--- a/src/mozxchannel/git/process.py
+++ b/src/mozxchannel/git/process.py
@@ -124,7 +124,12 @@ class CommitsGraph:
         self.paths_for_repos[repo.name] = paths = references(pc, basepath)
         branches = repo.branches()
         self.branches[repo.name] = branches[:]
-        known_revs = self.revs.get(repo.name, {})
+
+        repo_name = repo.name
+        if "firefox-android" in repo_name:
+            repo_name = f"{repo_name}/{self.project}"
+        known_revs = self.revs.get(repo_name, {})
+
         for branch_num in range(len(branches)):
             branch = branches[branch_num]
             prior_branches = branches[:branch_num]


### PR DESCRIPTION
We weren't fetching the correct commit hash of the last known revision because we were using the incorrect repo name as the key in the getter for `self.revs`. As a result of this defect, we are grabbing the entire commit history from the start of time instead of starting from the last known revision that has been committed. See https://github.com/mozilla-l10n/android-l10n/pull/583 for example. When we are grabbing from the last known revision, we should see a much smaller number of commits that represents only the new string commits that have not been committed into the android-l10n repo. See https://github.com/mozilla-l10n/android-l10n/pull/582 for example.

The `self.revs` are parsed from the [_meta](https://github.com/mozilla-l10n/android-l10n/tree/master/_meta) json files  and appears as follow:

{'mozilla-mobile/android-components': {'main': '96444ddbd36acf0987ca531574187647bc74b5f3'}, 'mozilla-mobile/fenix': {'main': 'd039188782084c5475112e6d98ab829c7992e759'}, 'mozilla-mobile/focus-android': {'main': 'a9a09b171665081b4e5f4d426f0e30f22f84ae49'}, 'mozilla-mobile/firefox-android/focus-android': {'main': '4af98f17650c9c3215b7c24b497b99357ab8dc78'}}

`repo.name` is currently returning `mozilla-mobile/firefox-android`.

You can view some of the logs in https://github.com/mozilla-l10n/android-l10n-tooling/pull/56/checks?check_run_id=10718690309.