### PR TITLE
Bug 1814585 - part 2: Disable all update-project tasks but fenix

### DIFF
--- a/taskcluster/ci/update-project/kind.yml
+++ b/taskcluster/ci/update-project/kind.yml
@@ -28,15 +28,5 @@ job-defaults:
         command: ['import-android-l10n', '{l10n_toml_path}', '{project}']
 
 jobs:
-    mozilla-mobile/android-components:
-        repo-prefix: ac
     mozilla-mobile/fenix:
         repo-prefix: fenix
-    mozilla-mobile/focus-android:
-        repo-prefix: focusandroid
-    mozilla-mobile/firefox-android/android-components:
-        repo-prefix: firefoxandroid
-        l10n-toml-path: 'android-l10n/mozilla-mobile/android-components/l10n.toml'
-    mozilla-mobile/firefox-android/focus-android:
-        repo-prefix: firefoxandroid
-        l10n-toml-path: 'android-l10n/mozilla-mobile/focus-android/l10n.toml'


### PR DESCRIPTION
The goal is to leave only fenix running for now, then disable it when it moves to the mono-repo.

We should keep this not-merged for a couple of days, while we make sure that the automation in firefox-android runs correctly (so far it's been only manually triggered once)
https://github.com/mozilla-mobile/firefox-android/actions/workflows/import-l10n.yml