### PR TITLE
Bug 1814585 - part 3: Remove update-l10n hook

### DIFF
--- a/.cron.yml
+++ b/.cron.yml
@@ -4,12 +4,6 @@
 ---
 
 jobs:
-    - name: update-l10n
-      job:
-          type: decision-task
-          treeherder-symbol: upd-l10n
-          target-tasks-method: update-l10n
-      when: []  # hook only
     - name: update-projects
       job:
           type: decision-task


### PR DESCRIPTION
These tasks were basically no-op'ed in https://github.com/mozilla-l10n/android-l10n-tooling/pull/61. The hook has been complaining for some reason. Let's just remove it since they're deprecated.