### PR TITLE
Bug 1814585 - part 4:  Remove update-projects hook

### DIFF
--- a/.cron.yml
+++ b/.cron.yml
@@ -3,11 +3,4 @@
 # `taskcluster/docs/cron.rst`.
 ---
 
-jobs:
-    - name: update-projects
-      job:
-          type: decision-task
-          treeherder-symbol: upd-proj
-          target-tasks-method: update-projects
-      when:
-          - {hour: 0, minute: 0}
+jobs: {}

--- a/taskcluster/ci/update-project/kind.yml
+++ b/taskcluster/ci/update-project/kind.yml
@@ -27,6 +27,4 @@ job-defaults:
                 path: android-l10n
         command: ['import-android-l10n', '{l10n_toml_path}', '{project}']
 
-jobs:
-    mozilla-mobile/fenix:
-        repo-prefix: fenix
+jobs: {}


### PR DESCRIPTION
⚠️ Do not land before Tuesday, February 14th, 2023.